### PR TITLE
Set specific engine version by sha1

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ You can pass the following arguments from the command line to the script:
 ```bash
 --architectures <arg>           Comma separated list of architectures to include: js-web,wasm-web (default = wasm-web).
 --embed-archive-js <arg>        Embed `_archive.js` file: true/false (default = true).
+--engine-sha1 <arg>             Set sha1 of a specific version of the engine to be used (stable version by default)
 
 # The following arguments passed to Bob.jar as is:
 --build-server <arg>            The build server (default = https://build.defold.com).

--- a/playable_ad/gulpfile.js
+++ b/playable_ad/gulpfile.js
@@ -46,7 +46,7 @@ const Vinyl = require("vinyl");
 
 const knownOptions = {
   boolean: ["embed-archive-js"],
-  string: ["architectures", "build-server", "settings", "variant", "texture-compression"],
+  string: ["architectures", "build-server", "settings", "variant", "texture-compression", "engine-sha1"],
   default: {
     architectures: "wasm-web",
     "embed-archive-js": true,
@@ -176,7 +176,8 @@ function javaIsInstalled(cb) {
 }
 
 function fetchBobVersionInfo(cb) {
-  https
+  if (options["engine-sha1"] == undefined) {
+    https
     .get(bobJarVersionInfoUrl, function (res) {
       res.setEncoding("utf8");
 
@@ -197,6 +198,12 @@ function fetchBobVersionInfo(cb) {
     .on("error", function (e) {
       cb(e);
     });
+  } else {
+    bobJarVersionInfo = {
+      sha1: options["engine-sha1"]
+    }
+    cb();
+  }
 }
 
 function downloadBobJar(cb) {

--- a/playable_ad/gulpfile.js
+++ b/playable_ad/gulpfile.js
@@ -178,26 +178,26 @@ function javaIsInstalled(cb) {
 function fetchBobVersionInfo(cb) {
   if (options["engine-sha1"] == undefined) {
     https
-    .get(bobJarVersionInfoUrl, function (res) {
-      res.setEncoding("utf8");
+      .get(bobJarVersionInfoUrl, function (res) {
+        res.setEncoding("utf8");
 
-      let body = "";
-      res.on("data", function (data) {
-        body += data;
+        let body = "";
+        res.on("data", function (data) {
+          body += data;
+        });
+        res.on("end", function () {
+          bobJarVersionInfo = JSON.parse(body);
+
+          if (!/^[a-f0-9]{40}$/i.test(bobJarVersionInfo.sha1)) {
+            throw "Invalid bob.jar SHA-1.";
+          }
+
+          cb();
+        });
+      })
+      .on("error", function (e) {
+        cb(e);
       });
-      res.on("end", function () {
-        bobJarVersionInfo = JSON.parse(body);
-
-        if (!/^[a-f0-9]{40}$/i.test(bobJarVersionInfo.sha1)) {
-          throw "Invalid bob.jar SHA-1.";
-        }
-
-        cb();
-      });
-    })
-    .on("error", function (e) {
-      cb(e);
-    });
   } else {
     bobJarVersionInfo = {
       sha1: options["engine-sha1"]


### PR DESCRIPTION
Issue:
Project is always build with latest engine version.

Fix:
I've added new option `--engine-sha1 <arg> ` for gulp to set a specific engine version by sha1.
If no sha1 is set, project builds as it used to, with latest stable version.

Example:
For Defold 1.7.0 run
`gulp --engine-sha1 bf4dc66ab5fbbafd4294d32c2797c08b630c0be5` 

Possible further improvements:
Set engine version, instead of sha1.